### PR TITLE
Stream name

### DIFF
--- a/lib/http_eventstore/event.rb
+++ b/lib/http_eventstore/event.rb
@@ -1,7 +1,7 @@
 require 'securerandom'
 
-class Event < Struct.new(:type, :data, :event_id, :id)
-  def initialize(type, data, event_id = nil, id = nil)
+class Event < Struct.new(:type, :data, :event_id, :id, :stream_name)
+  def initialize(type, data, event_id=nil, id=nil, stream_name=nil)
     event_id = SecureRandom.uuid if event_id.nil?
     super
   end

--- a/lib/http_eventstore/helpers/parse_entries.rb
+++ b/lib/http_eventstore/helpers/parse_entries.rb
@@ -15,7 +15,8 @@ module HttpEventstore
         event_id = entry['eventId']
         type = entry['eventType']
         data = JSON.parse(entry['data'])
-        Event.new(type, data, event_id, id)
+        stream_name = entry['streamName']
+        Event.new(type, data, event_id, id, stream_name)
       end
     end
   end

--- a/lib/http_eventstore/helpers/parse_entries.rb
+++ b/lib/http_eventstore/helpers/parse_entries.rb
@@ -15,7 +15,7 @@ module HttpEventstore
         event_id = entry['eventId']
         type = entry['eventType']
         data = JSON.parse(entry['data'])
-        stream_name = entry['streamName']
+        stream_name = entry['streamId']
         Event.new(type, data, event_id, id, stream_name)
       end
     end

--- a/spec/parse_entries_spec.rb
+++ b/spec/parse_entries_spec.rb
@@ -13,6 +13,7 @@ module HttpEventstore
         expect(events[0].data).to eq({"a" => "1"})
         expect(events[0].event_id).to eq "fbf4a1a1-b4a3-4dfe-a01f-6668634e16e4"
         expect(events[0].id).to eq 47
+        expect(events[0].stream_name).to eq('entries')
       end
 
       private
@@ -22,6 +23,7 @@ module HttpEventstore
           "eventType" => "entryCreated",
           "data" => "{\n  \"a\": \"1\"\n}",
           "positionEventNumber" => 47,
+          "streamId" => 'entries'
          }]
       end
     end


### PR DESCRIPTION
When using categories of events, it is necessary to have the stream name of the event so that the proper action can be taken.

```ruby
client = HttpEventstore::Connection.new

stream_name = 'accounts-001'
event_data = { event_type: "AccountCreated",
               data: { phoneNumber: '15125551234' }}
client.append_to_stream(stream_name, event_data)

EventData = Struct.new(:data, :event_type)

event_data = EventData.new({amount: 1000}, "DepositCreated")
client.append_to_stream(stream_name, event_data)

all_accounts_stream_name = '$ce-accounts'
events = client.read_all_events_forward(all_accounts_stream_name)

@balances = {}

events.each do |event|
  if event.type == "AccountCreated"
    @balances[event.stream_name] = {amount: 0, position: event.id}
  elsif event.type == "DepositCreated"
    prev_balance = @balances[event.stream_name][:amount]
    @balances[event.stream_name] = {amount: prev_balance + event.data['amount'], position: event.id}
  end
end

# ?> @balances
# => {"accounts-001"=>{:amount=>1000, :position=>5}}
```