### PR TITLE
Stream positions

### DIFF
--- a/lib/http_eventstore/event.rb
+++ b/lib/http_eventstore/event.rb
@@ -1,7 +1,7 @@
 require 'securerandom'
 
-class Event < Struct.new(:type, :data, :event_id, :id, :stream_name)
-  def initialize(type, data, event_id=nil, id=nil, stream_name=nil)
+class Event < Struct.new(:type, :data, :event_id, :id, :position, :stream_name)
+  def initialize(type, data, event_id=nil, id=nil, position=nil, stream_name=nil)
     event_id = SecureRandom.uuid if event_id.nil?
     super
   end

--- a/lib/http_eventstore/event.rb
+++ b/lib/http_eventstore/event.rb
@@ -1,7 +1,7 @@
 require 'securerandom'
 
-class Event < Struct.new(:type, :data, :event_id, :id)
-  def initialize(type, data, event_id = nil, id = nil)
+class Event < Struct.new(:type, :data, :event_id, :id, :stream_name)
+  def initialize(type, data, event_id=nil, id=nil, stream_name=nil)
     event_id = SecureRandom.uuid if event_id.nil?
     super
   end

--- a/lib/http_eventstore/helpers/parse_entries.rb
+++ b/lib/http_eventstore/helpers/parse_entries.rb
@@ -15,7 +15,8 @@ module HttpEventstore
         event_id = entry['eventId']
         type = entry['eventType']
         data = JSON.parse(entry['data'])
-        Event.new(type, data, event_id, id)
+        stream_name = entry['streamName']
+        Event.new(type, data, event_id, id, stream_name)
       end
     end
   end

--- a/lib/http_eventstore/helpers/parse_entries.rb
+++ b/lib/http_eventstore/helpers/parse_entries.rb
@@ -11,7 +11,6 @@ module HttpEventstore
       private
 
       def create_event(entry)
-        p entry
         id = entry['eventNumber']
         event_id = entry['eventId']
         type = entry['eventType']

--- a/lib/http_eventstore/helpers/parse_entries.rb
+++ b/lib/http_eventstore/helpers/parse_entries.rb
@@ -15,7 +15,7 @@ module HttpEventstore
         event_id = entry['eventId']
         type = entry['eventType']
         data = JSON.parse(entry['data'])
-        stream_name = entry['streamName']
+        stream_name = entry['streamId']
         Event.new(type, data, event_id, id, stream_name)
       end
     end

--- a/lib/http_eventstore/helpers/parse_entries.rb
+++ b/lib/http_eventstore/helpers/parse_entries.rb
@@ -11,12 +11,14 @@ module HttpEventstore
       private
 
       def create_event(entry)
-        id = entry['positionEventNumber']
+        p entry
+        id = entry['eventNumber']
         event_id = entry['eventId']
         type = entry['eventType']
         data = JSON.parse(entry['data'])
         stream_name = entry['streamId']
-        Event.new(type, data, event_id, id, stream_name)
+        position = entry['positionEventNumber']
+        Event.new(type, data, event_id, id, position, stream_name)
       end
     end
   end

--- a/spec/parse_entries_spec.rb
+++ b/spec/parse_entries_spec.rb
@@ -13,6 +13,7 @@ module HttpEventstore
         expect(events[0].data).to eq({"a" => "1"})
         expect(events[0].event_id).to eq "fbf4a1a1-b4a3-4dfe-a01f-6668634e16e4"
         expect(events[0].id).to eq 47
+        expect(events[0].stream_name).to eq('entries')
       end
 
       private
@@ -22,6 +23,7 @@ module HttpEventstore
           "eventType" => "entryCreated",
           "data" => "{\n  \"a\": \"1\"\n}",
           "positionEventNumber" => 47,
+          "streamId" => 'entries'
          }]
       end
     end

--- a/spec/parse_entries_spec.rb
+++ b/spec/parse_entries_spec.rb
@@ -13,6 +13,7 @@ module HttpEventstore
         expect(events[0].data).to eq({"a" => "1"})
         expect(events[0].event_id).to eq "fbf4a1a1-b4a3-4dfe-a01f-6668634e16e4"
         expect(events[0].id).to eq 47
+        expect(events[0].position).to eq 51
         expect(events[0].stream_name).to eq('entries')
       end
 
@@ -22,7 +23,8 @@ module HttpEventstore
         [{"eventId" => "fbf4a1a1-b4a3-4dfe-a01f-6668634e16e4",
           "eventType" => "entryCreated",
           "data" => "{\n  \"a\": \"1\"\n}",
-          "positionEventNumber" => 47,
+          "eventNumber" => 47,
+          "positionEventNumber" => 51,
           "streamId" => 'entries'
          }]
       end


### PR DESCRIPTION
Many times an event's position in a stream (like a category stream) is different from its ID.  This commit allows us to process events like this:

```ruby
{"eventId"=>"5d505741-54e6-4b6f-b759-e0d81f333e22", "eventType"=>"WithdrawalCreated", "eventNumber"=>13, "data"=>"{\"amount\":279}", "streamId"=>"accounts-002", "isJson"=>true, "isMetaData"=>false, "isLinkMetaData"=>false, "positionEventNumber"=>868, "positionStreamId"=>"$ce-accounts", "title"=>"13@accounts-002", "id"=>"http://localhost:2113/streams/accounts-002/13", "updated"=>"2015-04-07T20:57:21.11506Z", "author"=>{"name"=>"EventStore"}, "summary"=>"$>", "links"=>[{"uri"=>"http://localhost:2113/streams/accounts-002/13", "relation"=>"edit"}, {"uri"=>"http://localhost:2113/streams/accounts-002/13", "relation"=>"alternate"}]}
```

With code like this:

```ruby
def calculate_balances
  client = HttpEventstore::Connection.new
  all_accounts_stream_name = '$ce-accounts'
  events = client.read_events_forward(all_accounts_stream_name, @last_event+1, 1000).reverse

  events.each do |event|
    p event
    if event.type == "AccountCreated"
      @balances[event.stream_name] = {amount: 0, position: event.id}
    elsif event.type == "DepositCreated"
      prev_balance = @balances[event.stream_name][:amount]
      @balances[event.stream_name] = {amount: prev_balance + event.data['amount'], position: event.id}
    elsif event.type == "WithdrawalCreated"
      prev_balance = @balances[event.stream_name][:amount]
      @balances[event.stream_name] = {amount: prev_balance - event.data['amount'], position: event.id}
    end
    @last_event = event.position
  end

  @balances
end

#=> {"accounts-001"=>{:amount=>1168, :position=>856}, "accounts-002"=>{:amount=>632, :position=>14}}
#?> @last_event
#=> 871
```