### PR TITLE
Tolerate reading stream events forward if they encounter deleted events

### DIFF
--- a/lib/http_eventstore/helpers/parse_entries.rb
+++ b/lib/http_eventstore/helpers/parse_entries.rb
@@ -5,7 +5,7 @@ module HttpEventstore
       def call(entries)
         entries.collect do |entry|
           create_event(entry)
-        end
+        end.compact
       end
 
       private
@@ -14,6 +14,7 @@ module HttpEventstore
         id = entry['eventNumber']
         event_id = entry['eventId']
         type = entry['eventType']
+        return nil unless entry['data']
         data = JSON.parse(entry['data'])
         stream_name = entry['streamId']
         position = entry['positionEventNumber']

--- a/spec/parse_entries_spec.rb
+++ b/spec/parse_entries_spec.rb
@@ -17,17 +17,53 @@ module HttpEventstore
         expect(events[0].stream_name).to eq('entries')
       end
 
+      specify 'tolerates deleted stream events' do
+        events = service.call(entries_including_deleted_stream_events)
+        expect(events.length).to eq 1
+        expect(events[0].type).to eq "entryCreated"
+        expect(events[0].data).to eq({"a" => "1"})
+        expect(events[0].event_id).to eq "fbf4a1a1-b4a3-4dfe-a01f-6668634e16e4"
+        expect(events[0].id).to eq 47
+        expect(events[0].position).to eq 51
+        expect(events[0].stream_name).to eq('entries')
+      end
+
       private
 
       def entries
-        [{"eventId" => "fbf4a1a1-b4a3-4dfe-a01f-6668634e16e4",
+        [entry]
+      end
+
+      def entries_including_deleted_stream_events
+        [
+          entry,
+          deleted_stream_entry
+        ]
+      end
+
+
+      def entry
+        {
+          "eventId" => "fbf4a1a1-b4a3-4dfe-a01f-6668634e16e4",
           "eventType" => "entryCreated",
           "data" => "{\n  \"a\": \"1\"\n}",
           "eventNumber" => 47,
           "positionEventNumber" => 51,
           "streamId" => 'entries'
-         }]
+        }
       end
+
+      def deleted_stream_entry
+        {
+          "title"=>"2147483647@entries-123",
+          "id"=>"http://localhost:2113/streams/entries-123/2147483647",
+          "updated"=>"2015-05-23T17:29:50.933926Z",
+          "author"=>{"name"=>"EventStore"},
+          "summary"=>"$>",
+          "links"=>[{"uri"=>"http://localhost:2113/streams/entries-123/2147483647", "relation"=>"edit"}, {"uri"=>"http://localhost:2113/streams/entries-123/2147483647", "relation"=>"alternate"}]
+        }
+      end
+
     end
   end
 end


### PR DESCRIPTION
Sometimes I delete streams (in test and dev), and I noticed that if I delete a stream (either hard or soft), when I then try to re-read the corresponding category stream, the `ParseEntries` would blow up because references to the events from the deleted stream still reside in category stream.

For example:
```
es_client.append_to_stream("loans-123", {event_type: "TestEvent", data: {foo: :bar}})
=> ""
>> es_client.read_all_events_forward("$ce-loans")
=> [#<struct Event type="TestEvent", data={"foo"=>"bar"}, event_id="ba47cfdd-a420-46ef-9394-34a0bc30abb5", id=0, position=0, stream_name="loans-123">]
>> es_client.delete_stream("loans-123", true)
=> ""
>> es_client.read_all_events_forward("$ce-loans")
TypeError: no implicit conversion of nil into String
```

This fixes that.