### PR TITLE
Read all stream events is not recursive so can read arbitrarily long streams

### DIFF
--- a/lib/http_eventstore/actions/read_all_stream_events.rb
+++ b/lib/http_eventstore/actions/read_all_stream_events.rb
@@ -19,11 +19,18 @@ module HttpEventstore
       attr_reader :client
 
       def get_all_stream_entries(stream_name, start_point = nil, entries = [])
+        loop do
+          start_point, entries = get_next_stream_entries(stream_name, start_point, entries)
+          break if start_point.nil?
+        end
+        entries
+      end
+
+      def get_next_stream_entries(stream_name, start_point = nil, entries = [])
         stream_data = get_stream_batch(stream_name, start_point)
         entries = append_entries(entries, stream_data['entries'])
         start_point = get_next_start_point(stream_data['links'])
-        return entries if start_point.nil?
-        get_all_stream_entries(stream_name, start_point, entries)
+        [start_point, entries]
       end
 
       def return_events(entries)


### PR DESCRIPTION
This addresses https://github.com/arkency/http_eventstore/issues/6

It's not feasible to test in, say, rspec, but using the code from the issue I provided, you can verify that it is an issue.
