### PR TITLE
The created_time of an event is surfaced by the HTTP client

### DIFF
--- a/lib/http_eventstore/event.rb
+++ b/lib/http_eventstore/event.rb
@@ -1,7 +1,7 @@
 require 'securerandom'
 
-class Event < Struct.new(:type, :data, :event_id, :id, :position, :stream_name)
-  def initialize(type, data, event_id=nil, id=nil, position=nil, stream_name=nil)
+class Event < Struct.new(:type, :data, :event_id, :id, :position, :stream_name, :created_time)
+  def initialize(type, data, event_id=nil, id=nil, position=nil, stream_name=nil, created_time=nil)
     event_id = SecureRandom.uuid if event_id.nil?
     super
   end

--- a/lib/http_eventstore/helpers/parse_entries.rb
+++ b/lib/http_eventstore/helpers/parse_entries.rb
@@ -18,7 +18,8 @@ module HttpEventstore
         data = JSON.parse(entry['data'])
         stream_name = entry['streamId']
         position = entry['positionEventNumber']
-        Event.new(type, data, event_id, id, position, stream_name)
+        created_time = entry['updated'] ? Time.parse(entry['updated']) : nil
+        Event.new(type, data, event_id, id, position, stream_name, created_time)
       end
     end
   end

--- a/spec/parse_entries_spec.rb
+++ b/spec/parse_entries_spec.rb
@@ -15,6 +15,7 @@ module HttpEventstore
         expect(events[0].id).to eq 47
         expect(events[0].position).to eq 51
         expect(events[0].stream_name).to eq('entries')
+        expect(events[0].created_time).to eq(Time.parse("2015-06-30T02:02:01Z"))
       end
 
       specify 'tolerates deleted stream events' do
@@ -49,7 +50,8 @@ module HttpEventstore
           "data" => "{\n  \"a\": \"1\"\n}",
           "eventNumber" => 47,
           "positionEventNumber" => 51,
-          "streamId" => 'entries'
+          "streamId" => 'entries',
+          "updated" => "2015-06-30T02:02:01Z"
         }
       end
 


### PR DESCRIPTION
This surfaces the `updated` attribute of ES into a field that is more appropriately named `created_time`.